### PR TITLE
Removed device preview from dependencies

### DIFF
--- a/framy_annotation/CHANGELOG.md
+++ b/framy_annotation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.0-dev.2]
+- Removed device_preview from dependencies
+- Added useDevicePreview as param to FramyApp annotation
+
 ## [0.1.0-dev.1]
 - Added device_preview as a dependency
 

--- a/framy_annotation/lib/framy_annotation.dart
+++ b/framy_annotation/lib/framy_annotation.dart
@@ -1,4 +1,3 @@
 library framy_annotation;
 
 export 'src/framy_annotations.dart';
-export 'package:device_preview/device_preview.dart';

--- a/framy_annotation/lib/src/framy_annotations.dart
+++ b/framy_annotation/lib/src/framy_annotations.dart
@@ -6,8 +6,12 @@ abstract class FramyAnnotation {
 /// Specifies a location where generated Framy app will be placed
 /// Required to be used exactly once inside the app
 /// Typically annotates main app widget (e.g. MyApp, MainApp, etc)
+/// [useDevicePreview] - setting this to true will cause wrapping widgets in DevicePreview in generated Framy app
+/// we highly recommend using this feature,
+/// **IMPORTANT**: when it's set to true then it is required to add device_preview package as dependency in pubspec.yaml!
 class FramyApp extends FramyAnnotation {
-  const FramyApp();
+  final bool useDevicePreview;
+  const FramyApp({this.useDevicePreview = false});
 }
 
 const framyApp = FramyApp();

--- a/framy_annotation/pubspec.yaml
+++ b/framy_annotation/pubspec.yaml
@@ -6,9 +6,6 @@ version: 0.1.0-dev.1
 repository: https://github.com/Fidev-io/framy
 homepage: https://framy.dev
 
-dependencies:
-  device_preview: ^0.4.5
-
 environment:
   sdk: ">=2.5.0 <3.0.0"
 


### PR DESCRIPTION
Removed device preview from dependencies
Added useDevicePreview param to FramyApp annotation

Related to #11 