### PR TITLE
Using Canvas-kit to build showcase page, selecting devices DevicePreview on web

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -18,7 +18,7 @@ jobs:
       - run: flutter config --enable-web
       - run: flutter pub get
         working-directory: showcase
-      - run: flutter build web --release
+      - run: flutter build web --release --dart-define=FLUTTER_WEB_USE_SKIA=true
         working-directory: showcase
       - run: |
           cd showcase/build/web

--- a/framy_generator/lib/generator/widget_cutom_page_template_generator.dart
+++ b/framy_generator/lib/generator/widget_cutom_page_template_generator.dart
@@ -138,6 +138,7 @@ builder: (context) {
     return '''
 DevicePreview(
   enabled: FramyAppSettings.of(context).wrapWithDevicePreview,
+  devices: kIsWeb ? [iPhoneXs, iPhoneX, iPhoneXsMax, iPhoneXr] : Devices.all,
   style: DevicePreviewStyle(
     hasFrameShadow: false,
     toolBar: DevicePreviewToolBarStyle.light(

--- a/test_apps/counter_app/lib/main.app.framy.dart
+++ b/test_apps/counter_app/lib/main.app.framy.dart
@@ -1023,6 +1023,9 @@ class _FramyCustomPageState extends State<FramyCustomPage> {
               Expanded(
                 child: DevicePreview(
                   enabled: FramyAppSettings.of(context).wrapWithDevicePreview,
+                  devices: kIsWeb
+                      ? [iPhoneXs, iPhoneX, iPhoneXsMax, iPhoneXr]
+                      : Devices.all,
                   style: DevicePreviewStyle(
                     hasFrameShadow: false,
                     toolBar: DevicePreviewToolBarStyle.light(

--- a/test_apps/weight_tracker/lib/main.app.framy.dart
+++ b/test_apps/weight_tracker/lib/main.app.framy.dart
@@ -1112,6 +1112,9 @@ class _FramyCustomPageState extends State<FramyCustomPage> {
               Expanded(
                 child: DevicePreview(
                   enabled: FramyAppSettings.of(context).wrapWithDevicePreview,
+                  devices: kIsWeb
+                      ? [iPhoneXs, iPhoneX, iPhoneXsMax, iPhoneXr]
+                      : Devices.all,
                   style: DevicePreviewStyle(
                     hasFrameShadow: false,
                     toolBar: DevicePreviewToolBarStyle.light(


### PR DESCRIPTION
Resolves #149 

To use DevicePreview on web `--dart-define=FLUTTER_WEB_USE_SKIA=true` flag is required.
Currently only devices with notch are working in DevicePreview on web.